### PR TITLE
only print to stderr

### DIFF
--- a/cliolog/encoder.go
+++ b/cliolog/encoder.go
@@ -106,9 +106,11 @@ func (c *consoleEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field) 
 	// color the level symbol and log message based on the level.
 	c.colorLevel(final.buf, ent.Level)
 
-	if c.LevelKey != "" {
-		final.skipNextElementSeparator = true
+	final.skipNextElementSeparator = c.LevelKey != ""
 
+	// if the logger name matches NoPrefixName, we don't print a log level prefix
+	// or color the output.
+	if c.LevelKey != "" && ent.LoggerName != NoPrefixName {
 		// zap doesn't have a 'success' level, nor does it have an easy way to define
 		// custom logging levels.
 		//
@@ -123,7 +125,7 @@ func (c *consoleEncoder) EncodeEntry(ent zapcore.Entry, fields []zapcore.Field) 
 		}
 	}
 
-	if final.buf.Len() > origLen {
+	if final.buf.Len() > origLen && ent.LoggerName != NoPrefixName {
 		final.buf.AppendString(" ")
 	} else {
 		final.buf.Reset()

--- a/cliolog/named.go
+++ b/cliolog/named.go
@@ -5,4 +5,8 @@ const (
 	// messages with a [✔] symbol rather than their regular
 	// log level.
 	SuccessName = "clio.success"
+
+	// NoPrefixName is a designated logging name which prints
+	// messages without a prefix.
+	NoPrefixName = "clio.noprefix"
 )

--- a/example/main.go
+++ b/example/main.go
@@ -11,6 +11,10 @@ func main() {
 
 	clio.Infof("this is an example of calling clio.Infof with no argument %s")
 
+	clio.Log("hello %s from clio.Log", "world")
+	clio.Logf("hello %s from clio.Logf", "world")
+	clio.Logln("hello %s from clio.Logln", "world")
+
 	clio.Info("hello %s from clio.Info", "world")
 	clio.Infof("hello %s from clio.Infof", "world")
 	clio.Infoln("hello %s from clio.Infoln", "world")

--- a/example_log_level_test.go
+++ b/example_log_level_test.go
@@ -17,7 +17,7 @@ func Example_levelFromEnv() {
 
 // You can use `clio.Level.SetLevel()` to set the log level dynamically.
 func Example_dynamicLevel() {
-	clio.SetErrWriter(os.Stdout) // print to stdout just to show logs in the example.
+	clio.SetWriter(os.Stdout) // print to stdout just to show logs in the example.
 
 	clio.Level.SetLevel(zapcore.InfoLevel)
 	clio.Debug("this isn't printed")
@@ -29,7 +29,7 @@ func Example_dynamicLevel() {
 
 // You can use `clio.SetLevelFromString()` to set the log level dynamically from a provided string.
 func Example_levelFromString() {
-	clio.SetErrWriter(os.Stdout) // print to stdout just to show logs in the example.
+	clio.SetWriter(os.Stdout) // print to stdout just to show logs in the example.
 
 	clio.SetLevelFromString("info")
 	clio.Debug("this isn't printed")

--- a/example_usage_test.go
+++ b/example_usage_test.go
@@ -10,7 +10,7 @@ import (
 func Example_usage() {
 	clio.SetLevelFromString("debug")
 
-	clio.SetErrWriter(os.Stdout) // print to stdout just to show logs in the example.
+	clio.SetWriter(os.Stdout) // print to stdout just to show logs in the example.
 
 	// you can print basic logs like this
 	clio.Info("here's an info message")

--- a/global.go
+++ b/global.go
@@ -2,7 +2,6 @@ package clio
 
 import (
 	"io"
-	"log"
 	"os"
 	"sync"
 
@@ -57,8 +56,6 @@ var (
 
 	// errorWriter defaults to stderr
 	errorWriter = colorable.NewColorableStderr()
-	// outputWriter defaults to stdout
-	outputWriter = colorable.NewColorableStdout()
 
 	// stderr is a zap logger which writes to stderr
 	stderr = cliolog.New(
@@ -66,18 +63,12 @@ var (
 		cliolog.WithWriter(errorWriter),
 		cliolog.WithNoColor(&NoColor),
 	).Sugar()
-
-	// stdoutlog is a logger which writes to stdoutlog
-	stdoutlog = log.New(outputWriter, "", 0)
-
-	// stderrlog is a stdlib logger which writes to stderr
-	stderrlog = log.New(errorWriter, "", 0)
 )
 
-// SetErrWriter rebuilds the global zap logger with a specific writer.
+// SetWriter rebuilds the global zap logger with a specific writer.
 // All Info, Error, Warn, Debug, etc messages are sent here.
 // clio.Log messages are sent to stdout.
-func SetErrWriter(w io.Writer) {
+func SetWriter(w io.Writer) {
 	globalMu.Lock()
 	defer globalMu.Unlock()
 

--- a/log.go
+++ b/log.go
@@ -5,9 +5,9 @@ import (
 	"github.com/common-fate/clio/cliolog"
 )
 
-// Log prints to stdout.
+// Log prints to stderr with no prefix.
 func Logf(template string, args ...any) {
-	stdoutlog.Printf(template, args...)
+	S().Named(cliolog.NoPrefixName).Infof(template, args...)
 }
 
 // Info prints to stderr with an [i] indicator.
@@ -36,9 +36,9 @@ func Debugf(template string, args ...any) {
 	S().Debugf(template, args...)
 }
 
-// Logln prints to stdout using fmt.Sprintln.
+// Logln prints with no prefix using fmt.Sprintln.
 func Logln(args ...any) {
-	stdoutlog.Println(args...)
+	S().Named(cliolog.NoPrefixName).Infoln(args...)
 }
 
 // Infoln prints to stderr with an [i] indicator using fmt.Sprintln.
@@ -69,7 +69,7 @@ func Debugln(args ...any) {
 
 // Log uses fmt.Sprint to construct and log a message.
 func Log(args ...any) {
-	stdoutlog.Print(args...)
+	S().Named(cliolog.NoPrefixName).Info(args...)
 }
 
 // Info prints to stderr with an [i] indicator using fmt.Sprint.

--- a/log_test.go
+++ b/log_test.go
@@ -31,6 +31,22 @@ func TestError(t *testing.T) {
 
 	want := "[✘] my message\n"
 	if got != want {
-		t.Errorf("Info() = %q, want %q", got, want)
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
+func TestLog(t *testing.T) {
+	var b bytes.Buffer
+	SetWriter(&b)
+	NoColor = true
+
+	Log("my message")
+
+	got := b.String()
+
+	// should print without a prefix.
+	want := "my message\n"
+	if got != want {
+		t.Errorf("Log() = %q, want %q", got, want)
 	}
 }

--- a/log_test.go
+++ b/log_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestInfo(t *testing.T) {
 	var b bytes.Buffer
-	SetErrWriter(&b)
+	SetWriter(&b)
 	NoColor = true
 
 	Info("my message")
@@ -22,7 +22,7 @@ func TestInfo(t *testing.T) {
 
 func TestError(t *testing.T) {
 	var b bytes.Buffer
-	SetErrWriter(&b)
+	SetWriter(&b)
 	NoColor = true
 
 	Error("my message")

--- a/spacing.go
+++ b/spacing.go
@@ -1,15 +1,6 @@
 package clio
 
-import (
-	"strings"
-)
-
-// NewLine prints a newline to clio.ErrorWriter
+// NewLine prints a newline
 func NewLine() {
-	stderrlog.Println()
-}
-
-// NewLines prints n newline(s) to clio.ErrorWriter
-func NewLines(n int) {
-	stderrlog.Printf(strings.Repeat("\n", n))
+	Logln()
 }


### PR DESCRIPTION
Makes clio.Log* functions print to stderr, rather than stdout.

Renames a couple of functions to be more concise and removes the NewLines method as this encourages inconsistent spacing in log printing (hard to standardize on 2 spaces vs 3 for example)