### PR TITLE
fix timestamp format in file logger

### DIFF
--- a/cliolog/new.go
+++ b/cliolog/new.go
@@ -35,7 +35,7 @@ func New(level zap.AtomicLevel, opts ...func(*Options)) *zap.Logger {
 	if o.FileWriteSyncer != nil {
 		fec := zap.NewProductionEncoderConfig()
 		fec.EncodeTime = zapcore.TimeEncoder(func(t time.Time, pae zapcore.PrimitiveArrayEncoder) {
-			pae.AppendString(t.UTC().Format("2023-01-02T15:04:05Z0700"))
+			pae.AppendString(t.UTC().Format("2006-01-02T15:04:05Z0700"))
 		})
 		fileEncoder := zapcore.NewJSONEncoder(fec)
 

--- a/example/main.go
+++ b/example/main.go
@@ -9,6 +9,11 @@ func main() {
 	// set the level to 'debug' to demonstrate all messages being printed.
 	clio.SetLevelFromString("debug")
 
+	// uncomment to test file logging
+	// clio.SetFileLogging(cliolog.FileLoggerConfig{
+	// 	Filename: "log",
+	// })
+
 	clio.Infof("this is an example of calling clio.Infof with no argument %s")
 
 	clio.Log("hello %s from clio.Log", "world")


### PR DESCRIPTION
Previous: 
```
{"level":"info","ts":"11113-09-11T03:15:00Z","msg":"To add new registry use 'granted registry add <your_repo>'"}
{"level":"info","ts":"11113-09-11T03:15:00Z","msg":"To remove a registry use 'granted registry remove' and select from the options"}
{"level":"info","ts":"11113-09-11T03:15:00Z","msg":"To sync a registry use 'granted registry sync'"}
```

New Format: 
```
{"level":"info","ts":"2023-09-11T03:28:56Z","logger":"clio.noprefix","msg":"hello %s from clio.Logworld"}
{"level":"info","ts":"2023-09-11T03:28:56Z","logger":"clio.noprefix","msg":"hello world from clio.Logf"}
{"level":"info","ts":"2023-09-11T03:28:56Z","logger":"clio.noprefix","msg":"hello %s from clio.Logln world"}
```